### PR TITLE
[Breaking change] Transform to variables instead directly values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-for-var-in",
-  "version": "0.0.2",
+  "version": "1.0.0",
   "description": "Loops through vars in a file and expose them trough key value params",
   "main": "index.js",
   "scripts": {

--- a/test/basic/test.expect.css
+++ b/test/basic/test.expect.css
@@ -1,3 +1,3 @@
 .margin-space-1 {
-    margin: 2px
+    margin: var(--space-1)
 }

--- a/test/basic/test.result.css
+++ b/test/basic/test.result.css
@@ -1,3 +1,3 @@
 .margin-space-1 {
-    margin: 2px
+    margin: var(--space-1)
 }

--- a/test/malformed-import-syntax/test.result.css
+++ b/test/malformed-import-syntax/test.result.css
@@ -1,3 +1,3 @@
 .background-space-1 {
-    background-color: 2px
+    background-color: var(space-1)
 }

--- a/test/multiple-rules/test.expect.css
+++ b/test/multiple-rules/test.expect.css
@@ -1,29 +1,29 @@
 .margin-space-1 {
 
-    margin: 2px
+    margin: var(--space-1)
 }
 
 .margin-space-2 {
 
-    margin: 4px
+    margin: var(--space-2)
 }
 
 .margin-space-3 {
 
-    margin: 6px
+    margin: var(--space-3)
 }
 
 .margin-space-4 {
 
-    margin: 8px
+    margin: var(--space-4)
 }
 
 .color-black {
 
-    color: black
+    color: var(--black)
 }
 
 .color-white {
 
-    color: white
+    color: var(--white)
 }

--- a/test/multiple-rules/test.result.css
+++ b/test/multiple-rules/test.result.css
@@ -1,29 +1,29 @@
 .margin-space-1 {
 
-    margin: 2px
+    margin: var(--space-1)
 }
 
 .margin-space-2 {
 
-    margin: 4px
+    margin: var(--space-2)
 }
 
 .margin-space-3 {
 
-    margin: 6px
+    margin: var(--space-3)
 }
 
 .margin-space-4 {
 
-    margin: 8px
+    margin: var(--space-4)
 }
 
 .color-black {
 
-    color: black
+    color: var(--black)
 }
 
 .color-white {
 
-    color: white
+    color: var(--white)
 }

--- a/test/multiple-vars/test.expect.css
+++ b/test/multiple-vars/test.expect.css
@@ -1,12 +1,12 @@
 .margin-space-1 {
-    margin: 2px
+    margin: var(--space-1)
 }
 .margin-space-2 {
-    margin: 4px
+    margin: var(--space-2)
 }
 .margin-space-3 {
-    margin: 6px
+    margin: var(--space-3)
 }
 .margin-space-4 {
-    margin: 8px
+    margin: var(--space-4)
 }

--- a/test/multiple-vars/test.result.css
+++ b/test/multiple-vars/test.result.css
@@ -1,12 +1,12 @@
 .margin-space-1 {
-    margin: 2px
+    margin: var(--space-1)
 }
 .margin-space-2 {
-    margin: 4px
+    margin: var(--space-2)
 }
 .margin-space-3 {
-    margin: 6px
+    margin: var(--space-3)
 }
 .margin-space-4 {
-    margin: 8px
+    margin: var(--space-4)
 }

--- a/test/other-var-names/test.expect.css
+++ b/test/other-var-names/test.expect.css
@@ -1,3 +1,3 @@
 .margin-spacing-1 {
-    margin: 2px
+    margin: var(--spacing-1)
 }

--- a/test/other-var-names/test.result.css
+++ b/test/other-var-names/test.result.css
@@ -1,3 +1,3 @@
 .margin-spacing-1 {
-    margin: 2px
+    margin: var(--spacing-1)
 }


### PR DESCRIPTION
In order to be able to theme components using this plugin, we should keep variables as value instead the values of the variables.

Now, what this is doing is, on a list of variables, get the actual value of the variable and do the list as that:

```
.margin-0 { margin: 0px }
.margin-1 { margin: 1px; }
.margin-2 { margin: 2px; }
```

With this PR that would do:

```
.margin-0 { margin: var(--margin-0) }
.margin-1 { margin: var(--margin-1) }
.margin-2 { margin: var(--margin-2) }
```

So, it would be using variables and after the cssnext (or another plugin) will convert the variables to the actual value. That work should be done outside this plugin.

* [x] Change the way the value of the class is putted. Use the variable itself instead the value.
* [x] Some minor improvements of styling.
* [x] Fix tests
* [x] Bump version to 1.0.0 as it's a breaking change.